### PR TITLE
Implemented Save Table test steps for Phase Noise 

### DIFF
--- a/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseIntegratedNoise.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseIntegratedNoise.cs
@@ -92,40 +92,51 @@ namespace Signal_Source_Analyzer
             SSAX.SetPhaseNoise_ShowIntegratedNoiseTable(wnum, ShowIntegratedNoiseTable);
 
             SSAX.SetPhaseNoise_IntegratedRangeType(Channel, mnum, range, IntegratedNoiseTableRange1.IntegratedRangeType);
-            SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange1.Start);
-            SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange1.Stop);
-            if (IntegratedNoiseTableRange1.WeighthingFilter != "None")
+            if (IntegratedNoiseTableRange1.IntegratedRangeType != PhaseNoise_IntegratedRangeTypeEnum.OFF)
             {
-                SSAX.SetPhaseNoise_WeighthingFilter(Channel, mnum, range, IntegratedNoiseTableRange1.WeighthingFilter);
+                SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange1.Start);
+                SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange1.Stop);
+                if (IntegratedNoiseTableRange1.WeighthingFilter != "None")
+                {
+                    SSAX.SetPhaseNoise_WeightingFilter(Channel, mnum, range, IntegratedNoiseTableRange1.WeighthingFilter);
+                }
             }
 
             range = 2;
             SSAX.SetPhaseNoise_IntegratedRangeType(Channel, mnum, range, IntegratedNoiseTableRange2.IntegratedRangeType);
-            SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange2.Start);
-            SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange2.Stop);
-            if (IntegratedNoiseTableRange2.WeighthingFilter != "None")
+            if (IntegratedNoiseTableRange2.IntegratedRangeType != PhaseNoise_IntegratedRangeTypeEnum.OFF)
             {
-                SSAX.SetPhaseNoise_WeighthingFilter(Channel, mnum, range, IntegratedNoiseTableRange2.WeighthingFilter);
+                SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange2.Start);
+                SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange2.Stop);
+                if (IntegratedNoiseTableRange2.WeighthingFilter != "None")
+                {
+                    SSAX.SetPhaseNoise_WeightingFilter(Channel, mnum, range, IntegratedNoiseTableRange2.WeighthingFilter);
+                }
             }
 
             range = 3;
             SSAX.SetPhaseNoise_IntegratedRangeType(Channel, mnum, range, IntegratedNoiseTableRange3.IntegratedRangeType);
-            SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange3.Start);
-            SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange3.Stop);
-            if (IntegratedNoiseTableRange3.WeighthingFilter != "None")
+            if (IntegratedNoiseTableRange3.IntegratedRangeType != PhaseNoise_IntegratedRangeTypeEnum.OFF)
             {
-                SSAX.SetPhaseNoise_WeighthingFilter(Channel, mnum, range, IntegratedNoiseTableRange3.WeighthingFilter);
+                SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange3.Start);
+                SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange3.Stop);
+                if (IntegratedNoiseTableRange3.WeighthingFilter != "None")
+                {
+                    SSAX.SetPhaseNoise_WeightingFilter(Channel, mnum, range, IntegratedNoiseTableRange3.WeighthingFilter);
+                }
             }
 
             range = 4;
             SSAX.SetPhaseNoise_IntegratedRangeType(Channel, mnum, range, IntegratedNoiseTableRange4.IntegratedRangeType);
-            SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange4.Start);
-            SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange4.Stop);
-            if (IntegratedNoiseTableRange4.WeighthingFilter != "None")
+            if (IntegratedNoiseTableRange4.IntegratedRangeType != PhaseNoise_IntegratedRangeTypeEnum.OFF)
             {
-                SSAX.SetPhaseNoise_WeighthingFilter(Channel, mnum, range, IntegratedNoiseTableRange4.WeighthingFilter);
+                SSAX.SetPhaseNoise_Start(Channel, mnum, range, IntegratedNoiseTableRange4.Start);
+                SSAX.SetPhaseNoise_Stop(Channel, mnum, range, IntegratedNoiseTableRange4.Stop);
+                if (IntegratedNoiseTableRange4.WeighthingFilter != "None")
+                {
+                    SSAX.SetPhaseNoise_WeightingFilter(Channel, mnum, range, IntegratedNoiseTableRange4.WeighthingFilter);
+                }
             }
-
 
             UpgradeVerdict(Verdict.Pass);
         }

--- a/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseSpotNoise.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseSpotNoise.cs
@@ -41,6 +41,9 @@ namespace Signal_Source_Analyzer
         [Display("Show Spot Noise Table", Group: "Settings", Order: 20.01, Description: "Enable or disable displaying the spot noise table.")]
         public bool ShowSpotNoiseTable { get; set; }
 
+        [Display("Enable Spot Noise", Group: "Settings", Order: 20.02, Description: "Enables and disables spot noise calculation for the selected measurement number.")]
+        public bool EnableSpotNoise { get; set; }
+
         [Display("Decade Edges", Group: "Settings", Order: 20.04, Description: "Enables and disables the spot noise calculation on every decade offset frequency.")]
         public bool DecadeEdges { get; set; }
 
@@ -79,6 +82,7 @@ namespace Signal_Source_Analyzer
         public GeneralPhaseNoiseSpotNoise()
         {
             ShowSpotNoiseTable = false;
+            EnableSpotNoise = false;
             DecadeEdges = true;
 
             SpotFrequenciesUser1 = new SpotFrequencies();
@@ -103,25 +107,43 @@ namespace Signal_Source_Analyzer
             RunChildSteps(); //If the step supports child steps.
 
             SSAX.SetPhaseNoise_ShowSpotNoiseTable(wnum, ShowSpotNoiseTable);
-            if (DecadeEdges)
+            SSAX.SetPhaseNoise_SpotNoiseEnable(Channel, mnum, EnableSpotNoise);
+            SSAX.SetPhaseNoise_DecadeEdges(Channel, mnum, DecadeEdges);
+            
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 1, SpotFrequenciesUser1.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser1.SpotFrequencyEnabled)
             {
-                SSAX.SetPhaseNoise_DecadeEdges(Channel, mnum, DecadeEdges);
-            }
-            else
-            {
-                SSAX.SetPhaseNoise_DecadeEdges(Channel, mnum, DecadeEdges);
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 1, SpotFrequenciesUser1.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 1, SpotFrequenciesUser1.SpotFrequencyEnabled);
+            }
+
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 2, SpotFrequenciesUser2.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser2.SpotFrequencyEnabled)
+            {
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 2, SpotFrequenciesUser2.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 2, SpotFrequenciesUser2.SpotFrequencyEnabled);
+            }
+
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 3, SpotFrequenciesUser3.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser3.SpotFrequencyEnabled)
+            {
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 3, SpotFrequenciesUser3.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 3, SpotFrequenciesUser3.SpotFrequencyEnabled);
+            }
+
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 4, SpotFrequenciesUser4.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser4.SpotFrequencyEnabled)
+            {
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 4, SpotFrequenciesUser4.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 4, SpotFrequenciesUser4.SpotFrequencyEnabled);
+            }
+
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 5, SpotFrequenciesUser5.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser5.SpotFrequencyEnabled)
+            {
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 5, SpotFrequenciesUser5.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 5, SpotFrequenciesUser5.SpotFrequencyEnabled);
+            }
+
+            SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 6, SpotFrequenciesUser6.SpotFrequencyEnabled);
+            if (SpotFrequenciesUser6.SpotFrequencyEnabled)
+            {
                 SSAX.SetPhaseNoise_SpotFrequency(Channel, mnum, 6, SpotFrequenciesUser6.SpotFrequency);
-                SSAX.SetPhaseNoise_SpotFrequencyEnabled(Channel, mnum, 6, SpotFrequenciesUser6.SpotFrequencyEnabled);
             }
 
             UpgradeVerdict(Verdict.Pass);

--- a/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseSpurious.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/GeneralPhaseNoiseSpurious.cs
@@ -87,12 +87,17 @@ namespace Signal_Source_Analyzer
             SSAX.SetPhaseNoise_EnableSpurAnalysis(Channel, mnum, EnableSpurAnalysis);
             SSAX.SetPhaseNoise_SpurSensibility(Channel, mnum, SpurSensibility);
             SSAX.SetPhaseNoise_MinSpurLevel(Channel, mnum, MinSpurLevel);
-            SSAX.SetPhaseNoise_ThresholdTable(Channel, mnum, ThresholdTableList);
+            if (ThresholdTableList.Count > 0)
+            {
+                SSAX.SetPhaseNoise_ThresholdTable(Channel, mnum, ThresholdTableList);
+            }
             SSAX.SetPhaseNoise_OmitDisplayedSpur(Channel, mnum, OmitDisplayedSpur);
 
             SSAX.SetPhaseNoise_OmitUserSpecifiedSpurs(Channel, mnum, OmitUserSpecifiedSpurs);
-            SSAX.SetPhaseNoise_UserSpurTable(Channel, mnum, UserSpurTableList);
-
+            if (UserSpurTableList.Count > 0)
+            {
+                SSAX.SetPhaseNoise_UserSpurTable(Channel, mnum, UserSpurTableList);
+            }
 
 
             UpgradeVerdict(Verdict.Pass);

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseIntegratedNoiseTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseIntegratedNoiseTable.cs
@@ -1,0 +1,113 @@
+﻿using OpenTap;
+using OpenTap.Plugins.PNAX;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
+using System.Text;
+
+namespace Signal_Source_Analyzer
+{
+    [Display("Store Integrated Noise Table", Groups: new[] { "Signal Source Analyzer", "General", "Phase Noise" }, Description: "Insert a description here")]
+    public class StorePhaseNoiseIntegratedNoiseTable : TestStep
+    {
+        #region Settings
+        [Display("PNA", null, null, 0.1, false, null)]
+        public SSAX SSAX { get; set; }
+
+        [Display("Channel", "Choose which channel to grab data from.", "Measurements", 10.1, false, null)]
+        public int Channel { get; set; }
+
+        [Display("MNum", Groups: new[] { "Trace" }, Order: 11)]
+        public List<int> mnum { get; set; }
+
+        #endregion
+
+        public StorePhaseNoiseIntegratedNoiseTable()
+        {
+            Channel = 1;
+            mnum = new List<int>() { 1 };
+        }
+
+        public override void Run()
+        {
+            UpgradeVerdict(Verdict.NotSet);
+
+            RunChildSteps(); //If the step supports child steps.
+
+            List<string> ResultNames = new List<string>();
+            ResultNames.Add("Trace");
+            ResultNames.Add("Start Offset");
+            ResultNames.Add("Stop Offset");
+            ResultNames.Add("Weighting");
+            ResultNames.Add("Integ Noise");
+            ResultNames.Add("Residual FM");
+            ResultNames.Add("Residual AM");
+            ResultNames.Add("Residual PM");
+            ResultNames.Add("RMS Jitter");
+            ResultNames.Add("RMS Radian");
+            ResultNames.Add("RMS Degree");
+
+            // Find Traces
+            // Get all measurements for current channel
+            mnum = SSAX.GetChannelMeasurements(Channel);
+
+
+            // foreach trace
+            foreach (int measurement in mnum)
+            {
+                // for range = 1 to 4
+                for (int range = 1; range <= 4; range++)
+                {
+                    // find if range is different than off
+                    PhaseNoise_IntegratedRangeTypeEnum IntegratedRangeTyp = SSAX.GetPhaseNoise_IntegratedRangeType(Channel, measurement, range);
+                    if (IntegratedRangeTyp != PhaseNoise_IntegratedRangeTypeEnum.OFF)
+                    {
+                        List<IConvertible> ResultValues = new List<IConvertible>();
+
+                        // trace
+                        ResultValues.Add(measurement);
+
+                        // get start
+                        double start = SSAX.GetPhaseNoise_Start(Channel, measurement, range);
+                        ResultValues.Add(start);
+                        // get stop
+                        double stop = SSAX.GetPhaseNoise_Stop(Channel, measurement, range);
+                        ResultValues.Add(stop);
+                        // get weighting
+                        string weighting = SSAX.GetPhaseNoise_WeightingFilter(Channel, measurement, range);
+                        ResultValues.Add(weighting);
+                        // get Integ Noise
+                        double integNoise = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.IPN);
+                        ResultValues.Add(integNoise);
+                        // get RFM
+                        double RFM = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RFM);
+                        ResultValues.Add(RFM);
+                        // get RAM
+                        double RAM = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RAM);
+                        ResultValues.Add(RAM);
+                        // get RPM
+                        double RPM = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RPM);
+                        ResultValues.Add(RPM);
+                        // get RMS Jitter
+                        double RMSJitter = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RMSJ);
+                        ResultValues.Add(RMSJitter);
+                        // get RMS Radian
+                        double RMSRadian = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RMSR);
+                        ResultValues.Add(RMSRadian);
+                        // get RMS Degree
+                        double RMSDegree = SSAX.GetPhaseNoise_IntegratedNoise(Channel, measurement, range, PhaseNoiseIntegratedNoiseDataEnum.RMSD);
+                        ResultValues.Add(RMSDegree);
+
+                        // Publish
+                        Results.Publish($"PN_IntegratedNoise_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+                    }
+                }
+
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseIntegratedNoiseTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseIntegratedNoiseTable.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.Remoting.Channels;
 using System.Text;
 
 namespace Signal_Source_Analyzer

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpotNoiseTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpotNoiseTable.cs
@@ -1,0 +1,102 @@
+﻿using OpenTap;
+using OpenTap.Plugins.PNAX;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
+using System.Text;
+
+namespace Signal_Source_Analyzer
+{
+    [Display("Store Spot Noise Table", Groups: new[] { "Signal Source Analyzer", "General", "Phase Noise" }, Description: "Insert a description here")]
+    public class StorePhaseNoiseSpotNoiseTable : TestStep
+    {
+        #region Settings
+        [Display("PNA", null, null, 0.1, false, null)]
+        public SSAX SSAX { get; set; }
+
+        [Display("Channel", "Choose which channel to grab data from.", "Measurements", 10.1, false, null)]
+        public int Channel { get; set; }
+
+        [Display("MNum", Groups: new[] { "Trace" }, Order: 11)]
+        public List<int> mnum { get; set; }
+
+        #endregion
+
+        public StorePhaseNoiseSpotNoiseTable()
+        {
+            Channel = 1;
+            mnum = new List<int>() { 1 };
+        }
+
+        public override void Run()
+        {
+            UpgradeVerdict(Verdict.NotSet);
+
+            RunChildSteps(); //If the step supports child steps.
+
+            List<string> ResultNames = new List<string>();
+
+            // Get all measurements for current channel
+            mnum = SSAX.GetChannelMeasurements(Channel);
+
+            foreach (int measurement in mnum)
+            {
+                List<IConvertible> ResultValues = new List<IConvertible>();
+
+                // Trace
+                ResultNames.Add("Trace");
+                ResultValues.Add(measurement);
+
+                // Find if Decades is selected
+                bool decades = SSAX.GetPhaseNoise_DecadeEdges(Channel, measurement);
+
+                if (decades)
+                {
+                    // Get values
+                    List<double> XValues = SSAX.GetPhaseNoise_DecadeX(Channel, measurement);
+                    List<double> YValues = SSAX.GetPhaseNoise_DecadeY(Channel, measurement);
+
+                    // make sure X and Y are the same length
+                    if (XValues.Count != YValues.Count)
+                    {
+                        UpgradeVerdict(Verdict.Fail);
+                        return;
+                    }
+
+                    // for all values
+                    for (int i = 0; i < XValues.Count; i++)
+                    {
+                        // publish values
+                        ResultNames.Add(XValues[i].ToString());
+                        ResultValues.Add(YValues[i]);
+                    }
+                }
+
+                // for user 1-6
+                for (int n = 1; n <= 6; n++)
+                {
+                    // Find if user n is selected
+                    bool user = SSAX.GetPhaseNoise_SpotFrequencyEnabled(Channel, measurement, n);
+
+                    if (user)
+                    {
+                        // Get values
+                        double XValue = SSAX.GetPhaseNoise_SpotFrequency(Channel, measurement, n);
+                        double YValue = SSAX.GetPhaseNoise_SpotFrequencyValue(Channel, measurement, n);
+
+                        // publish values
+                        ResultNames.Add(XValue.ToString());
+                        ResultValues.Add(YValue);
+                    }
+                }
+
+                // publish values
+                Results.Publish($"PN_SpotNoise_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpotNoiseTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpotNoiseTable.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.Remoting.Channels;
 using System.Text;
 
 namespace Signal_Source_Analyzer

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpuriousTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpuriousTable.cs
@@ -1,0 +1,89 @@
+﻿using OpenTap;
+using OpenTap.Plugins.PNAX;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
+using System.Text;
+
+namespace Signal_Source_Analyzer
+{
+    [Display("Store Spurious Table", Groups: new[] { "Signal Source Analyzer", "General", "Phase Noise" }, Description: "Insert a description here")]
+    public class StorePhaseNoiseSpuriousTable : TestStep
+    {
+        #region Settings
+        [Display("PNA", null, null, 0.1, false, null)]
+        public SSAX SSAX { get; set; }
+
+        [Display("Channel", "Choose which channel to grab data from.", "Measurements", 10.1, false, null)]
+        public int Channel { get; set; }
+
+        [Display("MNum", Groups: new[] { "Trace" }, Order: 11)]
+        public List<int> mnum { get; set; }
+
+        #endregion
+
+        public StorePhaseNoiseSpuriousTable()
+        {
+            Channel = 1;
+            mnum = new List<int>() { 1 };
+        }
+
+        public override void Run()
+        {
+            UpgradeVerdict(Verdict.NotSet);
+
+            RunChildSteps(); //If the step supports child steps.
+
+
+            List<string> ResultNames = new List<string>();
+            ResultNames.Add("Trace");
+            ResultNames.Add("Spur");
+            ResultNames.Add("Offset");
+            ResultNames.Add("Power");
+            ResultNames.Add("Jitter");
+
+            // Get all measurements for current channel
+            mnum = SSAX.GetChannelMeasurements(Channel);
+
+            foreach (int measurement in mnum)
+            {
+
+                // Query Spurious table from instrument
+                List<DetectedSpur> detectedSpurs = SSAX.GetPhaseNoise_SpuriousData(Channel, measurement);
+
+                // if empty, no spurious
+                if (detectedSpurs.Count == 0)
+                {
+                    List<IConvertible> ResultValues = new List<IConvertible>();
+                    ResultValues.Add("");
+                    ResultValues.Add("");
+                    ResultValues.Add("");
+                    ResultValues.Add("");
+                    ResultValues.Add("");
+                    Results.Publish($"PN_Spurious_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+                }
+                else
+                // else, parse table and add to resultnmae and resultvalues
+                {
+                    int spurCounter = 0;
+                    foreach (DetectedSpur spur in detectedSpurs)
+                    {
+                        List<IConvertible> ResultValues = new List<IConvertible>();
+                        ResultValues.Add(measurement);
+                        ResultValues.Add(spurCounter + 1);
+                        ResultValues.Add(spur.Frequency);
+                        ResultValues.Add(spur.Power);
+                        ResultValues.Add(spur.Jitter);
+                        spurCounter++;
+                        Results.Publish($"PN_Spurious_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+                    }
+                }
+
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpuriousTable.cs
+++ b/Signal-Source-Analyzer/General/Phase Noise/StorePhaseNoiseSpuriousTable.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.Remoting.Channels;
 using System.Text;
 
 namespace Signal_Source_Analyzer


### PR DESCRIPTION
Implemented test steps

![image](https://github.com/user-attachments/assets/82b56427-4c64-44f0-9ed7-b0a011b4df88)

Store Spurious Table
Store Integrated Noise Table
Store Spot Noise Table

The test steps were tested using a SSA-X and a Signal Generator, the above test plan turns on RF on the SG at the beggining of the test plan, sets up a PN channel, triggers it and saves the tables. Finally the SG RF is turned off.

The published results match the values on the SSA-X screen:

![image](https://github.com/user-attachments/assets/2c6a21f9-71d1-4d75-b03e-aaeb2d0fd65a)

Here are the 3 tables:


[PN_IntegratedNoise_Channel_1-2025-01-17 17-24-48-Pass.xlsx](https://github.com/user-attachments/files/18509203/PN_IntegratedNoise_Channel_1-2025-01-17.17-24-48-Pass.xlsx)
[PN_SpotNoise_Channel_1-2025-01-17 17-24-48-Pass.xlsx](https://github.com/user-attachments/files/18509204/PN_SpotNoise_Channel_1-2025-01-17.17-24-48-Pass.xlsx)
[PN_Spurious_Channel_1-2025-01-17 17-24-48-Pass.xlsx](https://github.com/user-attachments/files/18509205/PN_Spurious_Channel_1-2025-01-17.17-24-48-Pass.xlsx)

Close #29 